### PR TITLE
Fix NIC naming for newer Linux distros.

### DIFF
--- a/isolinux.cfg
+++ b/isolinux.cfg
@@ -3,4 +3,4 @@ timeout 1
 label terraform
   menu label ^Install Ubuntu Server for Terraform
   kernel /install/vmlinuz
-  append  file=/cdrom/preseed/unattended.seed debian-installer/locale=en_US console-setup/layoutcode=us keyboard-configuration/layoutcode=us console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true initrd=/install/initrd.gz quiet --
+  append  file=/cdrom/preseed/unattended.seed debian-installer/locale=en_US console-setup/layoutcode=us keyboard-configuration/layoutcode=us console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true initrd=/install/initrd.gz quiet -- net.ifnames=0 biosdevname=0


### PR DESCRIPTION
Newer Linux distros with `systemd` are using new naming for NICs.
So for example starting of Ubuntu 16.04, no more `eth0`, `eth1` ... etc, but the names became something like that `ens1`, `ens2` (based on NIC type and how is it connected).

So this fix to use old naming to make the [pressed](https://github.com/Telmate/terraform-ubuntu-proxmox-iso/blob/fb5a4a23f08abcb2e78140f3dd214334b66fd75d/unattended.seed.m4#L4) works as expected.

Thanks.