### PR TITLE
Modify ./build-iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Build dependencies
 
 * `curl`(1).
 * `m4`(1).
-* `mkisofs`(1) from the `cdrtools` package available from MacPorts or
-  Homebrew.
+* `genisoimage`(1) from the `genisoimage` package available from Debian repostiory and other package archives for Linux.
+	* `mkisofs` and `xorrisofs` are alternatives that work with the same arguments as `genisoimage`.
 
 Runtime dependencies
 --------------------

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Features in the ISO
 
 * Configurable default user with SSH key and sudoer NOPASSWD access
 * The system clock is set to UTC
-* Auto partition virtual disk (/dev/vda) with LVM
+* Auto partition virtual disk (/dev/sda) with LVM
 * OpenSSH server is installed
 * Bring up only eth1 for flexible user-net SSH port forwarding
 * Includes script to auto-resize partitions to the current size of
-  vitual disk /etc/auto_resize_vda.sh
+  vitual disk /etc/auto_resize_sda.sh
 
 
 Building

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/auto_resize_sda.sh
+++ b/auto_resize_sda.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Use parted to extend root partition to available /dev/sda space
+END=$(parted /dev/sda print free  | grep Free | tail -1 | awk "{print \$2}")
+parted /dev/sda resizepart 2 $END
+parted /dev/sda resizepart 5 $END
+pvresize /dev/sda5
+VGROUP=$(mount | grep root | awk "{ print \$1 }")
+lvextend -l +100%FREE -r $VGROUP

--- a/auto_resize_vda.sh
+++ b/auto_resize_vda.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# Use parted to extend root partition to available /dev/vda space
-END=$(parted /dev/vda print free  | grep Free | tail -1 | awk "{print \$2}")
-parted /dev/vda resizepart 2 $END
-parted /dev/vda resizepart 5 $END
-pvresize /dev/vda5
-VGROUP=$(mount | grep root | awk "{ print \$1 }")
-lvextend -l +100%FREE -r $VGROUP

--- a/build-iso
+++ b/build-iso
@@ -64,7 +64,7 @@ m4 \
 
 echo Building a custom ISO
 # Build a custom ISO.
-mkisofs -r -V "Ubuntu $VERSION for Terraform" \
+genisoimage -r -V "Ubuntu $VERSION for Terraform" \
 	-cache-inodes -J -l -no-emul-boot \
 	-b isolinux/isolinux.bin \
 	-c isolinux/boot.cat \

--- a/build-iso
+++ b/build-iso
@@ -56,7 +56,7 @@ m4 \
 m4 \
 	-D __USERNAME__="$USERNAME" \
 	sudoers.m4 > "$COPY/sudoers"
-cp "$PUBLIC_KEY" "auto_resize_vda.sh" "$COPY/"
+cp "$PUBLIC_KEY" "auto_resize_sda.sh" "$COPY/"
 m4 \
 	-D __USERNAME__="$USERNAME" \
 	-D __PUBLIC_KEY__="$PUBLIC_KEY" \

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,7 @@
 : ${NICKNAME:="terraform"}
 
 # Arguments given to the download router.
-: ${VERSION:="18.04.4"}
+: ${VERSION:="16.04.6"}
 : ${DISTRO:="server"}
 : ${RELEASE:="latest"}
 

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,7 @@
 : ${NICKNAME:="terraform"}
 
 # Arguments given to the download router.
-: ${VERSION:="14.04.5"}
+: ${VERSION:="18.04.4"}
 : ${DISTRO:="server"}
 : ${RELEASE:="latest"}
 

--- a/late_command.sh.m4
+++ b/late_command.sh.m4
@@ -7,7 +7,7 @@ chown 1000:1000 \
 	/target/home/__USERNAME__/.ssh \
 	/target/home/__USERNAME__/.ssh/authorized_keys
 
-cp /cdrom/sudoers /cdrom/auto_resize_vda.sh /target/etc/
+cp /cdrom/sudoers /cdrom/auto_resize_sda.sh /target/etc/
 chmod 440 /target/etc/sudoers
 chown 0:0 /target/etc/sudoers
-chmod 755 /target/etc/auto_resize_vda.sh
+chmod 755 /target/etc/auto_resize_sda.sh

--- a/unattended.seed.m4
+++ b/unattended.seed.m4
@@ -11,7 +11,7 @@ d-i clock-setup/utc boolean true
 d-i time/zone string UTC
 
 # Partitions.
-d-i partman-auto/disk string /dev/vda
+d-i partman-auto/disk string /dev/sda
 d-i partman-auto/method string lvm
 d-i partman-lvm/device_remove_lvm boolean true
 d-i partman-md/device_remove_md boolean true


### PR DESCRIPTION
Change mkisofs to genisoimage to accommodate for incompatibility of mkisofs on Debian 10 Buster. Both ISO generation tools have the same command line parameters so no other arguments were changed. Tested and working on Debian 10 Buster.